### PR TITLE
create symlink to latest doc in build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,6 +33,10 @@ jobs:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Create symlink
+        run: |
+          latest_doc=$(ls -1d docs/*/ | sort | tail -n 1)
+          ln -s $(basename $latest_doc) docs/latest
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v1


### PR DESCRIPTION
Adds a symlink in the docs folder to the folder with the latest documentation. Jekyll then creates a copy with the name "latest" of the folder with the latest documentation during its build process.